### PR TITLE
Add documentation for spectra and fitting

### DIFF
--- a/docs/src/fitting.md
+++ b/docs/src/fitting.md
@@ -1,0 +1,76 @@
+# Fitting utilities
+
+SpectraUtils exposes lightweight wrappers for probabilistic and deterministic
+spectral fitting. The core API revolves around defining a callable model that
+maps a parameter set to a `Spectrum`, then passing that model to one of the
+provided fit types.
+
+## Types and entry points
+
+- [`fit_spectrum`](@ref SpectraUtils.fit_spectrum)
+- [`FitResult`](@ref SpectraUtils.FitResult)
+- [`TuringFit`](@ref SpectraUtils.TuringFit)
+- [`LevenbergMarquardtFit`](@ref SpectraUtils.LevenbergMarquardtFit)
+
+`fit_spectrum` dispatches to the appropriate implementation once optional
+dependencies are loaded:
+
+- Load `using Turing` to enable Bayesian inference via `TuringFit` (see
+  `ext/SpectraUtilsTuringExt.jl`).
+- Load `using NonlinearSolve` to enable nonlinear least-squares fitting via
+  `LevenbergMarquardtFit` (see `ext/SpectraUtilsNonlinearSolveExt.jl`).
+
+The returned [`FitResult`](@ref SpectraUtils.FitResult) integrates with
+`StatsAPI`, exposing `coef`, `stderror`, `rss`, and related accessors for
+analysis and reporting.
+
+## Usage examples
+
+### Probabilistic fit with Turing
+
+```julia
+using SpectraUtils, Turing
+
+model = params -> Spectrum([
+  Line(params.amplitude, params.position, Voigt(0.01, 0.005)),
+])
+
+priors = (
+  amplitude = Normal(1.0, 0.3),
+  position = Normal(0.0, 0.05),
+)
+
+fit = TuringFit(model, priors)
+xs = range(-0.1, 0.1; length=100) |> collect
+ys = model((; amplitude=1.1, position=0.02)).(xs) .+ 0.01 .* randn(length(xs))
+
+result = fit_spectrum(fit, xs, ys; num_samples=500, progress=false)
+coef(result)           # posterior means for each parameter
+stderror(result)       # posterior standard deviations
+```
+
+### Deterministic Levenberg–Marquardt fit
+
+```julia
+using SpectraUtils, NonlinearSolve
+
+model = params -> Spectrum([
+  Line(params.amplitude, params.position, Gaussian(0.02)),
+])
+initial_guess = (
+  amplitude = 1.0,
+  position = 0.0,
+)
+
+lm = LevenbergMarquardtFit(model, initial_guess)
+xs = range(-0.2, 0.2; length=80) |> collect
+ys = model((; amplitude=0.9, position=0.015)).(xs)
+
+result = fit_spectrum(lm, xs, ys)
+coef(result)           # fitted parameter means
+rss(result)            # residual sum of squares
+```
+
+`FitResult` stores residuals and optional weights; these values propagate to the
+`StatsAPI` interface so that downstream tooling (e.g., reporting or diagnostics)
+can consume a consistent representation.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,7 +9,7 @@ line profiles. The package combines analytic line-shape functions, a convenient
 `Line` container, and physical helper formulas for estimating linewidths.
 
 ```@contents
-Pages = ["lineshapes.md", "lines.md", "linewidths.md"]
+Pages = ["lineshapes.md", "lines.md", "spectra.md", "fitting.md", "linewidths.md"]
 Depth = 2
 ```
 

--- a/docs/src/spectra.md
+++ b/docs/src/spectra.md
@@ -1,0 +1,34 @@
+# Spectra
+
+`Spectrum` bundles a collection of `Line` objects with an optional background
+function to produce complete spectral traces. Calling the resulting object
+returns the combined background and line contributions at a single position or
+broadcasts across an array of positions.
+
+## Types and constructors
+
+- [`Spectrum`](@ref SpectraUtils.Spectrum)
+
+A spectrum can be built from any iterable of lines. Pass a callable background
+as the second argument to account for offsets or slow drifts, or omit it to
+model only the summed line profiles.
+
+## Usage example
+
+```julia
+using SpectraUtils
+
+line1 = Line(0.8, -0.05, Gaussian(0.02))
+line2 = Line(1.3, 0.04, Lorentzian(0.01))
+background = x -> 0.01 + 0.02x
+
+spec = Spectrum([line1, line2], background)
+spec(0.0)               # evaluate at a single point
+
+xs = range(-0.2, 0.2; length=200) |> collect
+spec(xs)                # vectorized evaluation
+```
+
+When no background is provided, `Spectrum(lines)` defaults to summing the line
+profiles alone. The `Spectrum` call overloads optimize scalar and vector cases
+so that repeated evaluations during fitting or simulation stay efficient.

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -1,19 +1,54 @@
 using Distributions, Statistics
 
+"""
+    fit_spectrum(fit, xs, ys[, sigmas]; kwargs...)
+
+Fit the spectral model encoded by `fit` against the observations `ys` at
+positions `xs`. Dispatch is provided by extension modules: loading `Turing`
+enables Bayesian inference via [`TuringFit`](@ref), while loading
+`NonlinearSolve` enables deterministic fitting via
+[`LevenbergMarquardtFit`](@ref). If neither extension is available, an error is
+thrown indicating the missing dependency.
+"""
 fit_spectrum(x...) = error("Load Turing.jl to use this functionality.")
 
 
+"""
+    TuringFit(model, priors)
+
+Wrap a spectral `model` and `priors` into a callable object for probabilistic
+fitting with Turing. `model` should map a named tuple of parameters to a
+[`Spectrum`](@ref), while `priors` holds a matching set of `Distribution`
+objects. See [`fit_spectrum`](@ref) for usage examples.
+"""
 struct TuringFit{F,P}
   func::F
   params::P
 end
 
 
+"""
+    LevenbergMarquardtFit(model, initial_params)
+
+Wrap a spectral `model` and `initial_params` into a callable object for
+deterministic nonlinear least-squares fitting. The `initial_params` named tuple
+provides starting values (or optional priors) for each parameter used by
+`model`. Used in conjunction with [`fit_spectrum`](@ref) when
+`NonlinearSolve.jl` is available.
+"""
 struct LevenbergMarquardtFit{F,P}
   func::F
   params::P
 end
 
+"""
+    FitResult(params, resid, wt)
+
+Container returned by [`fit_spectrum`](@ref) encapsulating parameter
+posteriors or estimates (`params`), residuals (`resid`), and optional weights
+(`wt`). `FitResult` implements the `StatsAPI` interface, providing accessors
+such as `coef`, `stderror`, `rss`, and `weights` for downstream analysis.
+"""
 struct FitResult{P,R,W}
   params::P
   resid::R

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -1,3 +1,14 @@
+"""
+    Spectrum(lines, background=nothing)
+
+Bundle a collection of spectral `lines` with an optional `background` term into
+one callable model. When a background function is provided, evaluations return
+the sum of all line profiles and the background at the queried position; when
+`background` is `nothing`, only the line contributions are returned.
+
+Both scalar and array inputs are supported. The specialized methods ensure fast
+evaluation in tight fitting loops by avoiding unnecessary allocations.
+"""
 struct Spectrum{T,B}
   lines::T
   background::B


### PR DESCRIPTION
## Summary
- add a spectra page describing Spectrum construction, backgrounds, and usage examples
- document fitting utilities with examples for Turing and NonlinearSolve backends
- include the new documentation pages in the site contents

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c2b21fc0832f955901bddc0f7165)